### PR TITLE
add sessions caching for smother ui and some anims

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -9,7 +9,6 @@ import {SignupComponent} from "./controllers/signup/signup.component";
 import {PastComponent} from "./controllers/past/past.component";
 import {NotFoundComponent} from "./controllers/not-found/not-found.component";
 import {DisclaimerComponent} from "./controllers/disclaimer/disclaimer.component";
-
 /*
  * APP ROUTES. This is where Angular keeps its routes. You can see all the route titles and activated middleware.
  */
@@ -56,6 +55,8 @@ const routes: Routes = [
     data: {title: "Route not found"}
   },
 ];
+
+
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import {ActivatedRoute, NavigationEnd, Router, RoutesRecognized} from "@angular/
 export class AppComponent {
   title = 'app';
 
+
   constructor(private router: Router, private titleService: Title) {
     router.events.subscribe(event => { //Check for route change.
       if (event instanceof RoutesRecognized) {

--- a/src/app/controllers/home/home.component.html
+++ b/src/app/controllers/home/home.component.html
@@ -1,6 +1,7 @@
 <div id="header">
-  <p>Your Sessions</p>
+  <p>Your sessions</p>
 </div>
+<div class="lds-ring" *ngIf="sessions$ == undefined"><div></div><div></div><div></div><div></div></div>
 <div id="sessions">
   <ul [@listStagger]="sessions$">
     <li *ngIf="len == 0">
@@ -13,7 +14,7 @@
       <p><b>Category: </b> {{session.category}}</p>
       <p><b>Date: </b> {{session.date}} </p>
       <p><b>Open Seats: </b> {{session.openSeats}}</p>
-      <p><b>Classroom: </b> {{session.classroom}}</p>
+      <p><b>Room: </b> {{session.classroom}}</p>
     </li>
   </ul>
 </div>

--- a/src/app/controllers/home/home.component.ts
+++ b/src/app/controllers/home/home.component.ts
@@ -1,10 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import {Title} from "@angular/platform-browser";
-
 import {animate, query, stagger, style, transition, trigger} from "@angular/animations";
 import {AuthenticationService} from "../../core/services/authentication.service";
 import {AvailableSessions} from "../../core/models/available-sessions";
 import {SessionPayload} from "../../core/models/session-payload";
+import {SessionsService} from "../../../sessions.service"
 
 @Component({
   selector: 'app-home',
@@ -18,7 +18,7 @@ import {SessionPayload} from "../../core/models/session-payload";
             style({ opacity: 0, transform: 'translateY(-15px)' }),
             stagger('50ms',
               animate('550ms ease-out',
-                style({opacity: 1, transform: 'translateY(0px)'})))
+                style({opacity: .7, transform: 'translateY(0px)'})))
           ], { optional: true }),
           query(':leave', animate('50ms', style({ opacity: 0 })) ,{
             optional: true
@@ -31,14 +31,48 @@ export class HomeComponent implements OnInit {
 
   sessions$: AvailableSessions;
   len: number;
+  
 
-  constructor(private auth: AuthenticationService) { }
+  constructor(private auth: AuthenticationService, private sessions: SessionsService) { }
 
   ngOnInit() {
-    this.auth.getSignedup().subscribe(data => {this.sessions$ = data.sessions; this.len = data.sessions.length;});
+
+    this.updateHomeSessions(); //homeSessions is actually 'signed up' sessions (they are displayed on home page)
+    this.sessions.getHomeSessions();
+    
+    setTimeout(() =>
+      {
+        this.updateHomeSessions();
+        
+      },
+      2000);
+
   }
 
-  leave(session: SessionPayload){
-    this.auth.leave(session).subscribe(data => {this.auth.getSignedup().subscribe(data => {this.sessions$ = data.sessions; this.len = data.sessions.length;})});
+  leave(session: SessionPayload) {
+    this.len = 0;
+    this.sessions$ = null;
+    this.sessions.leaveHomeSession(session);
+    //this.sessions.getHomeSessions();
+    setTimeout(() =>
+      {
+        this.updateHomeSessions();
+      },
+      2000);
+  }
+
+  updateHomeSessions() {
+
+    if (!(JSON.stringify(this.sessions$) === JSON.stringify(this.sessions.homeSessions$))) { //this is really broken but the only way I got it to compare the arrays
+
+      this.sessions$ = this.sessions.homeSessions$;
+      this.len = this.sessions.homeLength;
+    } else if (this.sessions.homeSessions$ == undefined) { //if homeSessions$ has not been updated, check again periodically
+      setTimeout(() =>
+      {
+        this.updateHomeSessions();
+      },
+      2000);
+    } 
   }
 }

--- a/src/app/controllers/login/login.component.ts
+++ b/src/app/controllers/login/login.component.ts
@@ -14,7 +14,7 @@ import {state, style, trigger, animate, transition, animation, useAnimation} fro
     trigger('submitAnimation', [
       // ...
       state('idle', style({
-        backgroundColor: ' #bf0127';
+        backgroundColor: '#bf0127'
       })),
       state('failed', style({
         backgroundColor: '#ff4579'

--- a/src/app/controllers/past/past.component.html
+++ b/src/app/controllers/past/past.component.html
@@ -1,6 +1,7 @@
 <div id="header">
   <p>Past sessions</p>
 </div>
+<div class="lds-ring" *ngIf="sessions$ == undefined"><div></div><div></div><div></div><div></div></div>
 <div id="sessions">
   <ul [@listStagger]="sessions$">
     <li *ngIf="len == 0">

--- a/src/app/controllers/past/past.component.ts
+++ b/src/app/controllers/past/past.component.ts
@@ -3,6 +3,9 @@ import {Title} from "@angular/platform-browser";
 import {AuthenticationService} from "../../core/services/authentication.service";
 import {animate, query, stagger, style, transition, trigger} from "@angular/animations";
 import {PastSessions} from "../../core/models/past-sessions";
+import {SessionsService} from "../../../sessions.service"
+
+
 
 @Component({
   selector: 'app-past',
@@ -16,7 +19,7 @@ import {PastSessions} from "../../core/models/past-sessions";
             style({ opacity: 0, transform: 'translateY(-15px)' }),
             stagger('50ms',
               animate('550ms ease-out',
-                style({opacity: 1, transform: 'translateY(0px)'})))
+                style({opacity: .7, transform: 'translateY(0px)'})))
           ], { optional: true }),
           query(':leave', animate('50ms', style({ opacity: 0 })) ,{
             optional: true
@@ -30,9 +33,32 @@ export class PastComponent implements OnInit {
   sessions$: PastSessions;
   len: number;
 
-  constructor(private auth: AuthenticationService) { }
+  constructor(private auth: AuthenticationService, private sessions: SessionsService) { }
 
   ngOnInit() {
-    this.auth.getPast().subscribe(data => {this.sessions$ = data.sessions; this.len = data.sessions.length;});
+
+    this.updatePastSessions();
+    this.sessions.getPastSessions();
+    
+    setTimeout(() =>
+      {
+        this.updatePastSessions();
+      },
+      1000);
+  }
+
+  updatePastSessions() {
+
+    if (!(JSON.stringify(this.sessions$) === JSON.stringify(this.sessions.pastSessions$))) { //this is really broken but the only way I got it to compare the arrays
+
+      this.sessions$ = this.sessions.pastSessions$;
+      this.len = this.sessions.pastLength;
+    } else if (this.sessions.pastSessions$ == undefined) { //if pastSessions$ has not been updated, check again periodically
+      setTimeout(() =>
+      {
+        this.updatePastSessions();
+      },
+      1000);
+    } 
   }
 }

--- a/src/app/controllers/signup/signup.component.html
+++ b/src/app/controllers/signup/signup.component.html
@@ -2,9 +2,10 @@
   <p>Available sessions</p>
   <div class="search">
     <form>
-      <input title="searchText" name="searchText" type="text" [(ngModel)]="searchText" class="searchText" placeholder="Search sessions...">
+      <input title="searchText" name="searchText" type="text" [(ngModel)]="searchText" class="searchText" placeholder="Search sessions by title...">
     </form>
   </div>
+  <div class="lds-ring" *ngIf="sessions$ == undefined"><div></div><div></div><div></div><div></div></div>
 </div>
 <div id="sessions">
   <ul [@listStagger]="sessions$">

--- a/src/app/controllers/signup/signup.component.ts
+++ b/src/app/controllers/signup/signup.component.ts
@@ -4,6 +4,8 @@ import {animate, query, stagger, style, transition, trigger} from "@angular/anim
 import {AvailableSessions} from "../../core/models/available-sessions";
 import {SessionPayload} from "../../core/models/session-payload";
 import {Router} from "@angular/router";
+import {SessionsService} from "../../../sessions.service"
+
 
 @Component({
   selector: 'app-signup',
@@ -17,7 +19,7 @@ import {Router} from "@angular/router";
             style({ opacity: 0, transform: 'translateY(-15px)' }),
             stagger('50ms',
               animate('550ms ease-out',
-                style({opacity: 1, transform: 'translateY(0px)'})))
+                style({opacity: .7, transform: 'translateY(0px)'})))
           ], { optional: true }),
           query(':leave', animate('50ms', style({ opacity: 0 })) ,{
             optional: true
@@ -28,7 +30,7 @@ import {Router} from "@angular/router";
 })
 export class SignupComponent implements OnInit {
 
-  constructor(private auth: AuthenticationService , private router: Router) {
+  constructor(private auth: AuthenticationService , private router: Router, private sessions: SessionsService) {
   }
 
   searchText: string;
@@ -36,14 +38,34 @@ export class SignupComponent implements OnInit {
   len: number;
 
   ngOnInit() {
-    this.auth.getAvailable().subscribe(data => {
-      this.sessions$ = data.sessions;
-      this.len = data.sessions.length;
-    });
+
+    this.updateAvailableSessions();
+    this.sessions.getAvailableSessions();
+    
+    setTimeout(() =>
+      {
+        this.updateAvailableSessions();
+      },
+      1000);
   }
 
   signup(session: SessionPayload){
       this.auth.signup(session).subscribe(data => {this.router.navigateByUrl('/');});
+  }
+
+  updateAvailableSessions() {
+
+    if (!(JSON.stringify(this.sessions$) === JSON.stringify(this.sessions.availableSessions$))) { //this is really broken but the only way I got it to compare the arrays
+
+      this.sessions$ = this.sessions.availableSessions$;
+      this.len = this.sessions.availableLength;
+    } else if (this.sessions.availableSessions$ == undefined) { //if availableSessions$ has not been updated, check again periodically
+      setTimeout(() =>
+      {
+        this.updateAvailableSessions();
+      },
+      1000);
+    } 
   }
 
 }

--- a/src/app/core/services/authentication.service.ts
+++ b/src/app/core/services/authentication.service.ts
@@ -68,7 +68,6 @@ export class AuthenticationService {
     if (method === 'post' && type === 'login') { //Check and see if we are logging in. If we are' provide the auth payload
       base = this.http.post(this.config.getAPIURL() + type, user);
     } else if (method === 'post' && (type === 'sessions/signup' || type === 'sessions/leave' )) { //Check if we're doing something with sessions that requires the payload. //TODO add API call for leaving a session
-      console.log("Test");
       base = this.http.post(this.config.getAPIURL() + type, session, {headers: {Authorization: `Bearer ${this.getToken()}`}});
     } else {
       base = this.http.get(this.config.getAPIURL() + type, {headers: {Authorization: `Bearer ${this.getToken()}`}}); //Well, its probably some lame call that only needs auth.

--- a/src/sessions.service.spec.ts
+++ b/src/sessions.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { SessionsService } from './sessions.service';
+
+describe('SessionsService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SessionsService]
+    });
+  });
+
+  it('should be created', inject([SessionsService], (service: SessionsService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/sessions.service.ts
+++ b/src/sessions.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import {AvailableSessions} from "./app/core/models/available-sessions";
+import {PastSessions} from "./app/core/models/past-sessions";
+import {AuthenticationService} from "./app/core/services/authentication.service";
+import {SessionPayload} from "./app/core/models/session-payload";
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SessionsService { //this serves as a cache to keep the sessions stored even as you move around tabs
+
+  homeSessions$: AvailableSessions;
+  homeLength: number;
+  availableSessions$: AvailableSessions;
+  availableLength: number;
+  pastSessions$: PastSessions;
+  pastLength: number;
+
+  constructor(private auth: AuthenticationService) { 
+    this.getHomeSessions();
+    this.getAvailableSessions();
+    this.getPastSessions();
+  }
+
+  getHomeSessions () {
+  	this.auth.getSignedup().subscribe(data => 
+  		{this.homeSessions$ = data.sessions; this.homeLength = data.sessions.length;});
+  }
+
+  leaveHomeSession (session: SessionPayload) {
+  	    this.auth.leave(session).subscribe(data => 
+  	    	{this.auth.getSignedup().subscribe(data => 
+  	    		{this.homeSessions$ = data.sessions; this.homeLength = data.sessions.length;})});
+  }
+
+  getAvailableSessions () {
+  	this.auth.getAvailable().subscribe(data => 
+  		{this.availableSessions$ = data.sessions; this.availableLength = data.sessions.length;});
+  }
+
+  getPastSessions () {
+  	this.auth.getPast().subscribe(data => 
+  		{this.pastSessions$ = data.sessions; this.pastLength = data.sessions.length;});
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -74,6 +74,7 @@ html, body {
         padding: 20px;
         margin-bottom: 8px;
         font-size: 1.5vh;
+        max-width: 50%;
 
         .options{
           float: right;
@@ -109,4 +110,44 @@ html, body {
     }
   }
 
+}
+//this is for the loading icon
+.lds-ring {
+  display: inline-block;
+  position: relative;
+  width: 64px;
+  height: 64px;
+  margin-left: 25%;
+  margin-top: 20px;
+
+
+}
+.lds-ring div {
+  box-sizing: border-box;
+  display: block;
+  position: absolute;
+  width: 35px;
+  height: 35px;
+  margin: 4px;
+  border: 4px solid #fff;
+  border-radius: 50%;
+  animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  border-color: #fff transparent transparent transparent;
+}
+.lds-ring div:nth-child(1) {
+  animation-delay: -0.45s;
+}
+.lds-ring div:nth-child(2) {
+  animation-delay: -0.3s;
+}
+.lds-ring div:nth-child(3) {
+  animation-delay: -0.15s;
+}
+@keyframes lds-ring {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
With a new service (sessions) all of the sessions get stored between tab
changes to remain persistent and prevent any waiting from occurring. Also,
there is now a loading icon that shows when waiting for the Core server.

Please squash and merge when merging this pr. 